### PR TITLE
security(admin): harden login protection and db scripts

### DIFF
--- a/scripts/init-db.sql
+++ b/scripts/init-db.sql
@@ -1,8 +1,4 @@
--- 激活码管理系统数据库初始化脚本（简化版本）
--- 在 Supabase 项目的 SQL 编辑器中执行此脚本
-
--- 设置数据库时区为亚洲/上海时区
-SET timezone = 'Asia/Shanghai';
+-- 激活码管理系统数据库初始化脚本
 
 -- 创建管理员用户表
 CREATE TABLE IF NOT EXISTS admin_users (
@@ -13,7 +9,7 @@ CREATE TABLE IF NOT EXISTS admin_users (
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 
--- 创建激活码表（简化版本）
+-- 创建激活码表
 CREATE TABLE IF NOT EXISTS activation_codes (
     id SERIAL PRIMARY KEY,
     code VARCHAR(20) UNIQUE NOT NULL,  -- 20位字母数字激活码
@@ -21,7 +17,20 @@ CREATE TABLE IF NOT EXISTS activation_codes (
     expires_at TIMESTAMP WITH TIME ZONE NULL,
     used_at TIMESTAMP WITH TIME ZONE NULL,
     used_by_device_id VARCHAR(255) NULL,
-    validity_days INTEGER NULL,  -- 激活后的有效天数：NULL=使用expires_at，1=日卡，30=月卡
+    validity_days INTEGER NULL CHECK (validity_days IS NULL OR validity_days > 0),  -- 激活后的有效天数
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- 创建管理员登录保护表
+-- 用于登录失败计数、限流和锁定控制
+CREATE TABLE IF NOT EXISTS admin_login_guards (
+    guard_key VARCHAR(128) PRIMARY KEY,
+    guard_type VARCHAR(20) NOT NULL CHECK (guard_type IN ('username', 'ip')),
+    failed_count INTEGER NOT NULL DEFAULT 0 CHECK (failed_count >= 0),
+    first_failed_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_failed_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    locked_until TIMESTAMP WITH TIME ZONE NULL CHECK (locked_until IS NULL OR locked_until >= first_failed_at),
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
@@ -36,6 +45,8 @@ CREATE INDEX IF NOT EXISTS idx_activation_codes_expires_at ON activation_codes(e
 CREATE INDEX IF NOT EXISTS idx_activation_codes_device_id ON activation_codes(used_by_device_id);
 CREATE INDEX IF NOT EXISTS idx_activation_codes_created_at ON activation_codes(created_at);
 CREATE INDEX IF NOT EXISTS idx_activation_codes_validity_days ON activation_codes(validity_days);
+CREATE INDEX IF NOT EXISTS idx_admin_login_guards_type ON admin_login_guards(guard_type);
+CREATE INDEX IF NOT EXISTS idx_admin_login_guards_locked_until ON admin_login_guards(locked_until);
 
 -- 创建更新时间触发器函数
 -- 使用 SECURITY DEFINER 和安全的 search_path 防止 search_path 劫持攻击
@@ -51,13 +62,32 @@ END;
 $$ language 'plpgsql';
 
 -- 为表添加更新时间触发器
-CREATE TRIGGER update_admin_users_updated_at 
-    BEFORE UPDATE ON admin_users 
-    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_trigger WHERE tgname = 'update_admin_users_updated_at'
+    ) THEN
+        CREATE TRIGGER update_admin_users_updated_at
+            BEFORE UPDATE ON admin_users
+            FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+    END IF;
 
-CREATE TRIGGER update_activation_codes_updated_at 
-    BEFORE UPDATE ON activation_codes 
-    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_trigger WHERE tgname = 'update_activation_codes_updated_at'
+    ) THEN
+        CREATE TRIGGER update_activation_codes_updated_at
+            BEFORE UPDATE ON activation_codes
+            FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_trigger WHERE tgname = 'update_admin_login_guards_updated_at'
+    ) THEN
+        CREATE TRIGGER update_admin_login_guards_updated_at
+            BEFORE UPDATE ON admin_login_guards
+            FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+    END IF;
+END $$;
 
 -- 管理员账号初始化说明
 -- 不再在数据库脚本中写入默认管理员，避免默认密码带来的安全风险
@@ -65,23 +95,41 @@ CREATE TRIGGER update_activation_codes_updated_at
 -- 系统只允许创建一个管理员账号，已初始化的系统不会展示 setup 页面
 
 -- ================================
--- Supabase 安全配置
+-- 安全配置
 -- ================================
 
 -- 启用行级安全策略 (RLS)
 ALTER TABLE admin_users ENABLE ROW LEVEL SECURITY;
 ALTER TABLE activation_codes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE admin_login_guards ENABLE ROW LEVEL SECURITY;
 
--- 为 admin_users 表创建 RLS 策略
--- 注意：由于这个应用使用直接数据库连接而不是 Supabase Auth，
--- 我们创建一个允许所有操作的策略，实际的安全控制在应用层实现
-CREATE POLICY "Enable all operations for admin_users" ON admin_users
-    FOR ALL USING (true) WITH CHECK (true);
+-- 为各表创建 RLS 策略
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public' AND tablename = 'admin_users' AND policyname = 'Enable all operations for admin_users'
+    ) THEN
+        CREATE POLICY "Enable all operations for admin_users" ON admin_users
+            FOR ALL USING (true) WITH CHECK (true);
+    END IF;
 
--- 为 activation_codes 表创建 RLS 策略
--- 同样，由于使用直接数据库连接，允许所有操作
-CREATE POLICY "Enable all operations for activation_codes" ON activation_codes
-    FOR ALL USING (true) WITH CHECK (true);
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public' AND tablename = 'activation_codes' AND policyname = 'Enable all operations for activation_codes'
+    ) THEN
+        CREATE POLICY "Enable all operations for activation_codes" ON activation_codes
+            FOR ALL USING (true) WITH CHECK (true);
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public' AND tablename = 'admin_login_guards' AND policyname = 'Enable all operations for admin_login_guards'
+    ) THEN
+        CREATE POLICY "Enable all operations for admin_login_guards" ON admin_login_guards
+            FOR ALL USING (true) WITH CHECK (true);
+    END IF;
+END $$;
 
 -- ================================
 -- 修复 SECURITY DEFINER 视图问题

--- a/scripts/migrate-add-admin-login-guards.sql
+++ b/scripts/migrate-add-admin-login-guards.sql
@@ -1,0 +1,63 @@
+-- 管理员登录保护表迁移脚本
+-- 用于给已部署系统补充登录失败计数、限流和锁定能力
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER
+SECURITY DEFINER
+SET search_path = 'pg_catalog'
+AS $$
+BEGIN
+    NEW.updated_at = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+CREATE TABLE IF NOT EXISTS admin_login_guards (
+    guard_key VARCHAR(128) PRIMARY KEY,
+    guard_type VARCHAR(20) NOT NULL CHECK (guard_type IN ('username', 'ip')),
+    failed_count INTEGER NOT NULL DEFAULT 0 CHECK (failed_count >= 0),
+    first_failed_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_failed_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    locked_until TIMESTAMP WITH TIME ZONE NULL CHECK (locked_until IS NULL OR locked_until >= first_failed_at),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_admin_login_guards_type
+ON admin_login_guards(guard_type);
+
+CREATE INDEX IF NOT EXISTS idx_admin_login_guards_locked_until
+ON admin_login_guards(locked_until);
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_trigger
+        WHERE tgname = 'update_admin_login_guards_updated_at'
+    ) THEN
+        CREATE TRIGGER update_admin_login_guards_updated_at
+            BEFORE UPDATE ON admin_login_guards
+            FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+    END IF;
+END $$;
+
+ALTER TABLE admin_login_guards ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename = 'admin_login_guards'
+          AND policyname = 'Enable all operations for admin_login_guards'
+    ) THEN
+        CREATE POLICY "Enable all operations for admin_login_guards" ON admin_login_guards
+            FOR ALL USING (true) WITH CHECK (true);
+    END IF;
+END $$;
+
+COMMIT;

--- a/scripts/migrate-add-validity-days.sql
+++ b/scripts/migrate-add-validity-days.sql
@@ -1,14 +1,26 @@
 -- 添加 validity_days 字段以支持相对过期时间（日卡/月卡）
 -- 执行时间：根据需要在数据库中执行此脚本
 
--- 设置数据库时区为亚洲/上海时区
-SET timezone = 'Asia/Shanghai';
+BEGIN;
 
 -- 1. 添加 validity_days 字段
 -- NULL: 使用 expires_at 的绝对过期时间（或永久有效）
 -- 数字: 激活后的有效天数（如 1=日卡, 30=月卡）
 ALTER TABLE activation_codes 
 ADD COLUMN IF NOT EXISTS validity_days INTEGER NULL;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'activation_codes_validity_days_check'
+    ) THEN
+        ALTER TABLE activation_codes
+            ADD CONSTRAINT activation_codes_validity_days_check
+            CHECK (validity_days IS NULL OR validity_days > 0);
+    END IF;
+END $$;
 
 -- 2. 添加注释说明
 COMMENT ON COLUMN activation_codes.validity_days IS '激活后的有效天数：NULL=使用expires_at绝对时间，1=日卡，30=月卡';
@@ -20,4 +32,4 @@ CREATE INDEX IF NOT EXISTS idx_activation_codes_validity_days ON activation_code
 -- 现有数据的 validity_days 为 NULL，将继续使用 expires_at 的绝对过期逻辑
 -- 新生成的日卡/月卡将使用 validity_days 字段
 
-SELECT 'Migration completed successfully!' as status;
+COMMIT;

--- a/src/app/api/admin/login/route.ts
+++ b/src/app/api/admin/login/route.ts
@@ -1,12 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server';
 import bcrypt from 'bcryptjs';
 import { jwtVerify } from 'jose';
-import { getAdminByUsername, isAdminSystemInitialized } from '@/lib/db';
+import {
+  clearAdminLoginFailures,
+  getAdminByUsername,
+  getAdminLoginGuardStatus,
+  isAdminSystemInitialized,
+  recordAdminLoginFailure
+} from '@/lib/db';
 import {
   createAdminSessionToken,
   getAdminSessionCookieOptions,
   getClearedAdminSessionCookieOptions
 } from '@/lib/admin-auth';
+import { getClientIP } from '@/lib/rate-limit';
 
 // 安全检查：确保 JWT_SECRET 已设置
 if (!process.env.JWT_SECRET || process.env.JWT_SECRET === 'your-secret-key') {
@@ -35,10 +42,12 @@ export async function POST(request: NextRequest) {
 
     // 解析请求体
     const body = await request.json();
-    const { username, password } = body;
+    const rawUsername = typeof body.username === 'string' ? body.username.trim() : '';
+    const rawPassword = typeof body.password === 'string' ? body.password : '';
+    const clientIP = getClientIP(request);
 
     // 验证请求参数
-    if (!username || !password) {
+    if (!rawUsername || !rawPassword) {
       return NextResponse.json(
         { 
           success: false, 
@@ -49,7 +58,7 @@ export async function POST(request: NextRequest) {
     }
 
     // 验证用户名格式
-    if (username.length < 3 || username.length > 50) {
+    if (rawUsername.length < 3 || rawUsername.length > 50) {
       return NextResponse.json(
         { 
           success: false, 
@@ -60,7 +69,7 @@ export async function POST(request: NextRequest) {
     }
 
     // 验证密码格式
-    if (password.length < 6) {
+    if (rawPassword.length < 6) {
       return NextResponse.json(
         { 
           success: false, 
@@ -70,31 +79,68 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    const guardStatus = await getAdminLoginGuardStatus(rawUsername, clientIP);
+    if (guardStatus.blocked) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: `登录失败次数过多，请在 ${Math.ceil(guardStatus.retryAfterSeconds / 60)} 分钟后重试`,
+          retryAfter: guardStatus.retryAfterSeconds
+        },
+        {
+          status: 429,
+          headers: {
+            'Retry-After': guardStatus.retryAfterSeconds.toString()
+          }
+        }
+      );
+    }
+
     // 查询管理员用户
-    const admin = await getAdminByUsername(username);
+    const admin = await getAdminByUsername(rawUsername);
 
     if (!admin) {
+      const failureStatus = await recordAdminLoginFailure(rawUsername, clientIP);
       // 为了安全，不透露具体是用户名错误还是密码错误
       return NextResponse.json(
         {
           success: false,
-          message: '用户名或密码错误'
+          message: failureStatus.blocked
+            ? `登录失败次数过多，请在 ${Math.ceil(failureStatus.retryAfterSeconds / 60)} 分钟后重试`
+            : '用户名或密码错误',
+          ...(failureStatus.blocked ? { retryAfter: failureStatus.retryAfterSeconds } : {})
         },
-        { status: 401 }
+        {
+          status: failureStatus.blocked ? 429 : 401,
+          headers: failureStatus.blocked
+            ? { 'Retry-After': failureStatus.retryAfterSeconds.toString() }
+            : undefined
+        }
       );
     }
 
     // 验证密码
-    const isPasswordValid = await bcrypt.compare(password, admin.password_hash);
+    const isPasswordValid = await bcrypt.compare(rawPassword, admin.password_hash);
     if (!isPasswordValid) {
+      const failureStatus = await recordAdminLoginFailure(rawUsername, clientIP);
       return NextResponse.json(
         {
           success: false,
-          message: '用户名或密码错误'
+          message: failureStatus.blocked
+            ? `登录失败次数过多，请在 ${Math.ceil(failureStatus.retryAfterSeconds / 60)} 分钟后重试`
+            : '用户名或密码错误',
+          ...(failureStatus.blocked ? { retryAfter: failureStatus.retryAfterSeconds } : {})
         },
-        { status: 401 }
+        {
+          status: failureStatus.blocked ? 429 : 401,
+          headers: failureStatus.blocked
+            ? { 'Retry-After': failureStatus.retryAfterSeconds.toString() }
+            : undefined
+        }
       );
     }
+
+    await clearAdminLoginFailures(rawUsername, clientIP);
 
     // 生成 JWT Token
     const token = await createAdminSessionToken({

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -3,13 +3,12 @@ import { Pool, PoolClient } from 'pg';
 // 数据库连接池配置 
 const dbConfig = {
   connectionString: process.env.DATABASE_URL,
-  ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
+  ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: true } : false,
   max: 5,
   min: 0,
   idleTimeoutMillis: 10000,
   connectionTimeoutMillis: 5000,
-  acquireTimeoutMillis: 10000,
-  options: '-c timezone=Asia/Shanghai',
+  maxUses: 7500,
 };
 
 // 全局连接池实例
@@ -169,6 +168,28 @@ export interface AdminUser {
   password_hash: string;
 }
 
+type AdminLoginGuardType = 'username' | 'ip';
+
+interface AdminLoginGuardRecord {
+  guard_key: string;
+  guard_type: AdminLoginGuardType;
+  failed_count: number;
+  first_failed_at: Date;
+  last_failed_at: Date;
+  locked_until: Date | null;
+}
+
+interface AdminLoginGuardConfig {
+  maxFailures: number;
+  windowMinutes: number;
+  lockMinutes: number;
+}
+
+export interface AdminLoginGuardStatus {
+  blocked: boolean;
+  retryAfterSeconds: number;
+}
+
 export interface ActivationCode {
   id: number;
   code: string;
@@ -178,6 +199,44 @@ export interface ActivationCode {
   used_by_device_id: string | null;
   created_at: Date;
   validity_days: number | null; // 激活后的有效天数：NULL=使用expires_at，1=日卡，30=月卡
+}
+
+const ADMIN_LOGIN_GUARD_CONFIGS: Record<AdminLoginGuardType, AdminLoginGuardConfig> = {
+  username: {
+    maxFailures: 5,
+    windowMinutes: 15,
+    lockMinutes: 30
+  },
+  ip: {
+    maxFailures: 10,
+    windowMinutes: 15,
+    lockMinutes: 15
+  }
+};
+
+function addMinutes(date: Date, minutes: number): Date {
+  return new Date(date.getTime() + minutes * 60 * 1000);
+}
+
+function getRetryAfterSeconds(lockedUntil: Date | null, now: Date): number {
+  if (!lockedUntil) {
+    return 0;
+  }
+
+  return Math.max(0, Math.ceil((lockedUntil.getTime() - now.getTime()) / 1000));
+}
+
+function normalizeLoginGuardRecord(
+  row: Record<string, unknown>
+): AdminLoginGuardRecord {
+  return {
+    guard_key: String(row.guard_key),
+    guard_type: row.guard_type as AdminLoginGuardType,
+    failed_count: Number(row.failed_count),
+    first_failed_at: new Date(String(row.first_failed_at)),
+    last_failed_at: new Date(String(row.last_failed_at)),
+    locked_until: row.locked_until ? new Date(String(row.locked_until)) : null
+  };
 }
 
 // 数据库操作函数
@@ -244,6 +303,140 @@ export async function createInitialAdmin(
 
     return insertResult.rows[0] as AdminUser;
   });
+}
+
+/**
+ * 获取管理员登录保护状态
+ * 当用户名或 IP 任一被锁定时，禁止继续登录
+ */
+export async function getAdminLoginGuardStatus(
+  username: string,
+  ipAddress: string
+): Promise<AdminLoginGuardStatus> {
+  const result = await query(
+    `SELECT guard_key, guard_type, failed_count, first_failed_at, last_failed_at, locked_until
+     FROM admin_login_guards
+     WHERE guard_key = ANY($1::text[])`,
+    [[`username:${username}`, `ip:${ipAddress}`]]
+  );
+
+  const now = new Date();
+  let blocked = false;
+  let retryAfterSeconds = 0;
+
+  for (const row of result.rows) {
+    const record = normalizeLoginGuardRecord(row);
+    if (record.locked_until && record.locked_until > now) {
+      blocked = true;
+      retryAfterSeconds = Math.max(retryAfterSeconds, getRetryAfterSeconds(record.locked_until, now));
+    }
+  }
+
+  return {
+    blocked,
+    retryAfterSeconds
+  };
+}
+
+async function upsertAdminLoginGuardFailure(
+  client: PoolClient,
+  guardType: AdminLoginGuardType,
+  identifier: string
+): Promise<AdminLoginGuardStatus> {
+  const config = ADMIN_LOGIN_GUARD_CONFIGS[guardType];
+  const guardKey = `${guardType}:${identifier}`;
+  const now = new Date();
+
+  const existingResult = await client.query(
+    `SELECT guard_key, guard_type, failed_count, first_failed_at, last_failed_at, locked_until
+     FROM admin_login_guards
+     WHERE guard_key = $1
+     FOR UPDATE`,
+    [guardKey]
+  );
+
+  let failedCount = 1;
+  let firstFailedAt = now;
+  let lockedUntil: Date | null = null;
+
+  if (existingResult.rows.length > 0) {
+    const existingRecord = normalizeLoginGuardRecord(existingResult.rows[0]);
+    const windowExpired = addMinutes(existingRecord.first_failed_at, config.windowMinutes) <= now;
+    const activeLock = existingRecord.locked_until && existingRecord.locked_until > now;
+
+    failedCount = windowExpired ? 1 : existingRecord.failed_count + 1;
+    firstFailedAt = windowExpired ? now : existingRecord.first_failed_at;
+    lockedUntil = activeLock ? existingRecord.locked_until : null;
+
+    if (failedCount >= config.maxFailures) {
+      lockedUntil = addMinutes(now, config.lockMinutes);
+    }
+
+    await client.query(
+      `UPDATE admin_login_guards
+       SET failed_count = $2,
+           first_failed_at = $3,
+           last_failed_at = $4,
+           locked_until = $5
+       WHERE guard_key = $1`,
+      [guardKey, failedCount, firstFailedAt, now, lockedUntil]
+    );
+  } else {
+    if (failedCount >= config.maxFailures) {
+      lockedUntil = addMinutes(now, config.lockMinutes);
+    }
+
+    await client.query(
+      `INSERT INTO admin_login_guards (
+         guard_key,
+         guard_type,
+         failed_count,
+         first_failed_at,
+         last_failed_at,
+         locked_until
+       ) VALUES ($1, $2, $3, $4, $5, $6)`,
+      [guardKey, guardType, failedCount, firstFailedAt, now, lockedUntil]
+    );
+  }
+
+  return {
+    blocked: lockedUntil !== null && lockedUntil > now,
+    retryAfterSeconds: getRetryAfterSeconds(lockedUntil, now)
+  };
+}
+
+/**
+ * 记录管理员登录失败
+ * 同时按用户名和 IP 两个维度更新失败计数与锁定状态
+ */
+export async function recordAdminLoginFailure(
+  username: string,
+  ipAddress: string
+): Promise<AdminLoginGuardStatus> {
+  return transaction(async (client) => {
+    const usernameStatus = await upsertAdminLoginGuardFailure(client, 'username', username);
+    const ipStatus = await upsertAdminLoginGuardFailure(client, 'ip', ipAddress);
+
+    return {
+      blocked: usernameStatus.blocked || ipStatus.blocked,
+      retryAfterSeconds: Math.max(usernameStatus.retryAfterSeconds, ipStatus.retryAfterSeconds)
+    };
+  });
+}
+
+/**
+ * 清理管理员登录失败状态
+ * 登录成功后重置用户名和 IP 两个维度的保护记录
+ */
+export async function clearAdminLoginFailures(
+  username: string,
+  ipAddress: string
+): Promise<void> {
+  await query(
+    `DELETE FROM admin_login_guards
+     WHERE guard_key = ANY($1::text[])`,
+    [[`username:${username}`, `ip:${ipAddress}`]]
+  );
 }
 
 /**


### PR DESCRIPTION
 ## 说明

  本 PR 主要加固管理员登录安全，并修复数据库初始化/迁移脚本的可靠性。

  ## 变更

  - 增加管理员登录失败计数与锁定机制
  - 按用户名和 IP 两个维度做持久化防爆破
  - 新增 `admin_login_guards` 迁移脚本
  - 修复 `init-db.sql` 的幂等性
  - 为关键字段补充基础约束
  - 收紧生产数据库 SSL 校验
  - 去掉数据库层时区强绑定

  ## 影响

  - 已部署系统需要执行新增迁移脚本：
    - `scripts/migrate-add-admin-login-guards.sql`
  - `validity_days` 迁移现在会校验非法数据，历史脏数据需要先处理